### PR TITLE
Add schema compatibility for older versions

### DIFF
--- a/napps_server/api/napps.py
+++ b/napps_server/api/napps.py
@@ -117,9 +117,12 @@ def register_napp(user):
     content = get_request_data(request, Napp.schema)
 
     # Get the name of the uploaded file
-    sent_file = request.files['file']
+    sent_file = request.files.get('file')
 
-    if not user.enabled or not content['username'] == user.username:
+    username = content.get('username')
+    napp_name = content.get('name')
+
+    if not user.enabled or not username == user.username:
         return Response("Permission denied", 401)
     elif not sent_file or not _allowed_file(sent_file.filename):
         return Response("Invalid file/file extension.", 401)
@@ -131,10 +134,10 @@ def register_napp(user):
     except InvalidNappMetaData:
         return Response("Permission denied. Invalid metadata.", 401)
 
-    user_repo = os.path.join(NAPP_REPO, content['username'])
+    user_repo = os.path.join(NAPP_REPO, username)
     os.makedirs(user_repo, exist_ok=True)
-    napp_latest = content['name'] + '-latest.napp'
-    napp_filename = _napp_versioned_name(content['username'], content['name'])
+    napp_latest = napp_name + '-latest.napp'
+    napp_filename = _napp_versioned_name(username, napp_name)
     # Move the file form the temporal folder to
     # the upload folder we setup
     sent_file.save(os.path.join(user_repo, napp_filename))
@@ -188,7 +191,7 @@ def delete_napp(username, name):
         napp.delete()
     except NappsEntryDoesNotExists:
         msg = 'Napp {} can\'t be deleted.'.format(name)
-        return  jsonify({'error': msg }), 404
+        return jsonify({'error': msg}), 404
 
     msg = 'Napp {} was deleted.'
     return jsonify({'success': msg}), 200

--- a/napps_server/core/models.py
+++ b/napps_server/core/models.py
@@ -494,7 +494,12 @@ class Napp(object):
             user (:class:`napps_server.core.models.User`):
                 Associate a user that belongs this Napp.
         """
-        self.user = User.get(content['username'])
+
+        # WARNING: This will be removed in future versions, when 'author' will
+        # be removed.
+        username = content.get('username', content.get('author'))
+
+        self.user = User.get(username)
         self.readme = ""
         if content is not None:
             self._populate_from_dict(content)
@@ -605,6 +610,9 @@ class Napp(object):
                 else:
                     data[key] = getattr(self, key, '')
         data['user'] = self.username
+        # WARNING: This will be removed in future versions, when 'author' will
+        # be removed.
+        data['author'] = self.username
         data['readme'] = self.readme_html
         return data
 

--- a/napps_server/core/utils.py
+++ b/napps_server/core/utils.py
@@ -70,4 +70,8 @@ def get_request_data(request, schema):
     if content is None:
         content = immutableMultiDict_to_dict(schema, request.form)
 
+    # WARNING: This will be removed in future versions, when 'author' will be
+    # removed.
+    content['username'] = content.get('author')
+
     return content


### PR DESCRIPTION
For now, need to keep 'author' and 'username' in some cases to keep compatibility. 'username' should be recognized in the server even if the kytos.json files pass only 'author'. We put warnings in the comments near code that shall be removed in future versions.